### PR TITLE
Fix argument type of Promise.prototype.catch

### DIFF
--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -3598,7 +3598,8 @@ interface Promise<T> {
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch(onrejected?: (reason: any) => T | PromiseLike<T>): Promise<T>;
+    catch<TResult>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+    catch<TResult>(onrejected?: (reason: any) => void): Promise<TResult>;
 
     [Symbol.toStringTag]: string;
 }


### PR DESCRIPTION
As per the Promise specifications [here](http://www.ecma-international.org/ecma-262/6.0/#sec-promise.prototype.catch), `Promise.prototype.catch` should accept a function that returns a value of type `TResult | PromiseLike<TResult>`, and have a return type of `Promise<TResult>`. 

According to the specs, `catch(onRejected)` should return the result `then(undefined, onRejected)`. The es6.d.ts definitions define the type of `onrejected` in `then` to be `(reason: any) => TResult | PromiseLike<TResult> | void`, and therefore `catch` should have the same argument type. Furthermore, `then` return a `Promise<TResult>`, so `catch` should return this as well.

This PR specifies the correct types for `catch`.
